### PR TITLE
Bump htmlint to 0.6.0 and update other dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
   },
   "homepage": "https://github.com/htmllint/htmllint-cli",
   "dependencies": {
-    "bluebird": "^3.4.0",
+    "bluebird": "^3.4.7",
     "chalk": "^1.1.3",
-    "cjson": "^0.4.0",
-    "glob": "^7.0.3",
-    "htmllint": "^0.3.0",
-    "liftoff": "^2.2.1",
+    "cjson": "^0.5.0",
+    "glob": "^7.1.1",
+    "htmllint": "^0.6.0",
+    "liftoff": "^2.3.0",
     "promise": "^7.1.1",
-    "semver": "^5.1.0",
-    "yargs": "^4.7.1"
+    "semver": "^5.3.0",
+    "yargs": "^6.6.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^2.5.3"
+    "mocha": "^3.2.0"
   }
 }


### PR DESCRIPTION
I realise this package hasn't received much love recently, but if someone could merge this and cut a new release, it would go a long way to unblocking progress downstream.

Closes #16.