### PR TITLE
Update dependencies

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -25,7 +25,6 @@ var argv = require('yargs')
             'Lints html files with htmllint.',
             'Usage: $0 [OPTIONS] [ARGS]'
         ].join('\n'))
-        .version(require('../package.json').version + '\n', 'version')
         .example('$0', 'lints all html files in the cwd and all child directories')
         .example('$0 init', 'creates a default .htmllintrc in the cwd')
         .example('$0 *.html', 'lints all html files in the cwd')
@@ -34,7 +33,6 @@ var argv = require('yargs')
         .describe('rc', 'path to a htmllintrc file to use (json)')
         .default('cwd', null)
         .describe('cwd', 'path to use for the current working directory')
-        .help('help')
         .argv;
 
 var args = argv._;

--- a/package.json
+++ b/package.json
@@ -15,16 +15,18 @@
     "url": "https://github.com/htmllint/htmllint-cli/issues"
   },
   "homepage": "https://github.com/htmllint/htmllint-cli",
+  "engines": {
+    "node": ">=4"
+  },
   "dependencies": {
-    "bluebird": "^3.4.7",
-    "chalk": "^1.1.3",
+    "bluebird": "^3.5.1",
+    "chalk": "^2.3.0",
     "cjson": "^0.5.0",
     "glob": "^7.1.1",
-    "htmllint": "^0.6.0",
-    "liftoff": "^2.3.0",
-    "promise": "^7.1.1",
-    "semver": "^5.3.0",
-    "yargs": "^6.6.0"
+    "htmllint": "^0.7.0",
+    "liftoff": "^2.5.0",
+    "semver": "^5.4.1",
+    "yargs": "^10.0.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This is mainly to update `htmllint` to the latest version: `0.7.0`

Also:
Fixes #17
Node >=4 is now required (same as `htmllint`)