### PR TITLE
Add format & stdin options

### DIFF
--- a/lib/formatters/index.js
+++ b/lib/formatters/index.js
@@ -1,0 +1,16 @@
+
+var formatters = {
+    simple: require('./simple'),
+    json: require('./json'),
+};
+
+exports.formatMessage = function (formatter, filename, issues) {
+    if (!(formatter in formatters)) {
+        throw ('[htmllint] formatter \'' + formatter + '\' not found');
+    }
+    formatters[formatter].formatMessage.call(this, filename, issues);
+};
+
+exports.done = function (formatter, errorCount, fileCount) {
+    formatters[formatter].done.call(this, errorCount, fileCount);
+};

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -1,0 +1,15 @@
+
+var results = [];
+
+exports.formatMessage = function (filename, issues) {
+    var that = this;
+    var result = {
+        filePath: filename,
+        messages: issues,
+    };
+    results.push(result);
+};
+
+exports.done = function (errorCount, fileCount) {
+    console.log(JSON.stringify(results));
+};

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -5,7 +5,11 @@ exports.formatMessage = function (filename, issues) {
     var that = this;
     var result = {
         filePath: filename,
-        messages: issues,
+        messages: issues.map(function (issue) {
+            return Object.assign({}, issue, {
+                message: that.messages.renderIssue(issue),
+            });
+        }),
     };
     results.push(result);
 };

--- a/lib/formatters/simple.js
+++ b/lib/formatters/simple.js
@@ -1,0 +1,22 @@
+
+var chalk = require('chalk');
+
+exports.formatMessage = function (filename, issues) {
+    var that = this;
+    issues.forEach(function (issue) {
+        var msg = [
+            chalk.magenta(filename), ': ',
+            'line ', issue.line, ', ',
+            'col ', issue.column, ', ',
+            chalk.red(that.messages.renderIssue(issue))
+        ].join('');
+
+        console.log(msg);
+    });
+};
+
+exports.done = function (errorCount, fileCount) {
+    console.log('');
+    console.log(chalk.yellow('[htmllint] found %d errors out of %d files'),
+        errorCount, fileCount);
+};


### PR DESCRIPTION
Hi,

I add formatter and stdin options to this cli command line interface.

I think it would help if we can specify lint result output format to JSON format.

Usage shown as blow:
```
Lints html files with htmllint.
Usage: cli.js [OPTIONS] [ARGS]

Options:
  --help             Show help                                         [boolean]
  --version          Show version number                               [boolean]
  --rc               path to a htmllintrc file to use (json)     [default: null]
  --format           output formatter (default: simple)      [default: "simple"]
  --cwd              path to use for the current working directory
                                                                 [default: null]
  --stdin-file-path  read html content from stdin and specify its file path
                                                                 [default: null]
```